### PR TITLE
Fix link to YEL calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ will sell you one without YEL. Because *YEL is the foundation* and a private hea
 * `YEL income`:
   * Has absolutely nothing to do with your real world income (salary, benefits, dividends, etc).
   * Is how much ***coverage*** in social security you would like to have.
-  * You have the freedom to choose between ~8,000€ up to ~180,000€ per year.
+  * You have the freedom to choose between 8,063.57€ up to 183,125€ per year.
 * `YEL contribution`:
   * Is how much you **pay** for your ***coverage***.
   * Is ~19% of your `YEL income`, which means you pay ~125€ up to ~2,820€ per month as a business cost.
@@ -469,7 +469,7 @@ Minimum YEL                |  Maximum YEL
 [maximum YEL image]: https://raw.githubusercontent.com/sam-hosseini/freelancing-in-finland/main/images/maximum_YEL.png
 [maximum YEL link]: https://raw.githubusercontent.com/sam-hosseini/freelancing-in-finland/main/images/maximum_YEL.png
 
-\* Taken from [Varma.fi YEL calculator](https://www.varma.fi/en/entrepreneur/entrepreneurs-calculator/)
+\* Taken from [Varma.fi YEL calculator for the Self-Employed](https://www.varma.fi/en/self-employed/yel-insurance/yel-calculator/)
 
 **Steps**:
 


### PR DESCRIPTION

This pr 
- Fixes the target of link to YEL calculator. The [existing one](https://www.varma.fi/en/entrepreneur/entrepreneurs-calculator/) seems to be broken (shows 404). 
- It also adjusts the minimum and maximum for the YEL income to show their exact amount.

Here are two screenshots that show the results on the calculator:

#### Minimum_YEL 
![minimum_YEL](https://user-images.githubusercontent.com/9104489/133938932-38ca6fc8-5c69-4942-9b5c-663d1099a628.png)


#### Maximum YEL
![maximum_YEL](https://user-images.githubusercontent.com/9104489/133938937-7f4dfe5a-b4f7-4b76-83b4-74368509dcb3.png)
 

 All the following conditions are met:
- [x] I have ensured that my PR respects the [target audience](https://github.com/sam-hosseini/freelancing-in-finland#how-can-this-guide-solve-the-problem) of this guide 👩‍💻👨‍💻
- [x] I have read this guide from beginning to the end to ensure that my PR respects the integrity of the guide as a whole 💯
- [x] I have ensured that my PR respects the strong opinions upon which the guide is based. One example would be [this](https://github.com/sam-hosseini/freelancing-in-finland/#take-out-money-from-your-company-in-the-most-tax-optimal-way) 🤝

Thank you!
