### PR TITLE
Tax percentage update

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,9 +518,9 @@ From the `employee`'s perspective:
 
 1. The employer withholds 20% of 1,000€ as `income tax` => 200€
 2. The employer withholds 7.15% of 1,000€ as `TyEL pension insurance contribution` => 71.5€
-3. The employer withholds 1.25% of 1,000€ as `unemployment insurance contribution` => 12.5€
-4. The employer pays withheld amount of 284€ to Tax Administration and other insurance providers.
-5. The *employee* receives the rest which is 716€.
+3. The employer withholds 1.50% of 1,000€ as `unemployment insurance contribution` => 15.0€
+4. The employer pays withheld amount of 286.5€ to Tax Administration and other insurance providers.
+5. The *employee* receives the rest which is 713.5€.
 
 From the `employer`'s perspective:
 


### PR DESCRIPTION
- [x] I have ensured that my PR respects the [target audience](https://github.com/sam-hosseini/freelancing-in-finland#how-can-this-guide-solve-the-problem) of this guide 👩‍💻👨‍💻
- [x] I have read this guide from beginning to the end to ensure that my PR respects the integrity of the guide as a whole 💯
- [x] I have ensured that my PR respects the strong opinions upon which the guide is based. One example would be [this](https://github.com/sam-hosseini/freelancing-in-finland/#take-out-money-from-your-company-in-the-most-tax-optimal-way) 🤝

Unemployment insurance taxation percentage is updated based on [2022 values](https://www.veronmaksajat.fi/Palkka-ja-elake/Tyottomyysvakuutusmaksut/tyottomyysvakuutusmaksut-2022/). In fact, the percentages in the employer's perspective are not up to date either. Employer's pension contribution is 17.4%, not 18.15% [[Source](https://www.veronmaksajat.fi/Palkka-ja-elake/Elakevakuutusmaksut/elakevakuutusmaksut-2022/)]. I haven't touched these because in general these percentages might change slightly every year (also depends on your age) so I would suggest you to put a disclaimer saying that these are approximate calculations.

Another missing info is YLE tax. Any Oy with more than 50k euros profit need to pay YLE tax as well. [[Source](https://www.vero.fi/tietoa-verohallinnosta/uutishuone/esitys_ja_opetusmateriaali/ylevero/)]
