### PR TITLE
Add hourly rate calculator to References

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ you must apply for SPOH compensation, with one application, within 6 months of t
 
 Calculators:
 * [Salary vs Dividend ratio optimizer](https://osinkoavaipalkkaa.fi/)
+* [Freelancer hourly rate calculator](https://arvento.fi/tuntihinta-laskuri) - calculates minimum hourly rate from target net income, accounting for Finnish progressive tax brackets, YEL pension contributions, and billable hours
 
 Guides:
 * [Suomi.fi](https://www.suomi.fi/company/)


### PR DESCRIPTION
Thank you for taking the time to create this PR!

I maintain this repository in my limited spare time.

For a smooth and timely review, please make sure your PR meets the following criteria:

- [x] I have ensured that my PR respects the [target audience](https://github.com/sam-hosseini/freelancing-in-finland#how-can-this-guide-solve-the-problem) of this guide.
- [x] I have read this guide from start to finish to ensure that my PR respects the integrity of the guide as a whole.
- [x] I have ensured that my PR respects the strong opinions upon which the guide is based. One example would be [this](https://github.com/sam-hosseini/freelancing-in-finland/#take-out-money-from-your-company-in-the-most-tax-optimal-way).

Thank you!

---

## What this PR does

Adds a single link to the **References > Calculators** section: a freelancer hourly rate calculator.

## Why this belongs here

The guide already explains hourly rate ranges (65-105 EUR for developers, 90-130 EUR for seniors) but doesn't provide a way for freelancers to calculate their own rate based on their specific situation.

The calculator solves a genuinely non-trivial problem: given a target net income, it reverse-engineers the minimum hourly rate by accounting for:

- Finnish progressive state tax (6 brackets)
- Municipal tax and church tax
- YEL pension contributions (mandatory for freelancers, covered extensively in this guide)
- Healthcare and YLE broadcasting levies
- Billable hours vs. total working hours

This is the kind of calculation that trips up new freelancers - the guide itself warns about setting rates too low. Having a calculator link next to the salary/dividend optimizer makes the References section more useful for the core audience: people setting up freelance businesses in Finland.

## Scope

One line added. No other changes to the guide content or structure.